### PR TITLE
Fix broken link in 4.0 docs

### DIFF
--- a/docs/source/admin-guide/certificate.md
+++ b/docs/source/admin-guide/certificate.md
@@ -38,7 +38,7 @@ The Gluu Server is compatible with the [Java KeyGenerator](https://docs.oracle.c
 To get KeyGenerator, run the following command inside the chroot:
 
 ```
-wget https://ox.gluu.org/maven/org.gluu/oxauth-client/4.0/oxauth-client-4.0-jar-with-dependencies.jar -O oxauth-client.jar
+wget https://ox.gluu.org/maven/org/gluu/oxauth-client/4.0.Final.patch1/oxauth-client-4.0.Final.patch1-jar-with-dependencies.jar -O oxauth-client.jar
 ```
 
 Then, run KeyGenerator with the following command:


### PR DESCRIPTION
Updating the Link of the `.jar` to generate the cryptographic keys. Similar to #6, but targeting 4.0 to keep the docs up to date. This one uses the most recent version, of the `4.0.X` releases.
The chosen target:
`https://ox.gluu.org/maven/org/gluu/oxauth-client/4.0.Final.patch1/oxauth-client-4.0.Final.patch1-jar-with-dependencies.jar`

Alternative targets:
`https://ox.gluu.org/maven/org/gluu/oxauth-client/4.0.1.Final/oxauth-client-4.0.1.Final-jar-with-dependencies.jar`