### PR TITLE
Updated Request an Access Token to the Token Endpoint

### DIFF
--- a/docs/source/user-management/scim2.md
+++ b/docs/source/user-management/scim2.md
@@ -184,6 +184,8 @@ $ curl -u '<authUsername>:<authPassword>' \
        https://<host-name>/oxauth/restv1/token
 ```
 
+If your Gluu Server uses self-signed certificate, include the `-k` option in the `curl` command.
+
 If you have problems creating your request, see section 4.4.2 of [OAuth 2.0](http://tools.ietf.org/html/rfc6749) for a deeper insight.
 
 ### Extract Token from Response


### PR DESCRIPTION
Added 'If your Gluu Server uses self-signed certificate, include the `-k` option in the `curl` command.'