### PR TITLE
Updated Installing OpenResty section

### DIFF
--- a/docs/source/integration/sswebapps/nginx.md
+++ b/docs/source/integration/sswebapps/nginx.md
@@ -20,9 +20,9 @@ First, you'll need to install a few dependencies for lua-resty-openidc. The [dep
 ```
 apt update
 apt-get install gcc libssl-dev libpcre3 libpcre3-dev
-wget https://openresty.org/download/openresty-1.11.2.5.tar.gz
-tar -xvf openresty-1.11.2.5.tar.gz 
-cd openresty-1.11.2.5
+wget https://openresty.org/download/openresty-1.19.3.1.tar.gz
+tar -xvf openresty-1.19.3.1.tar.gz 
+cd openresty-1.19.3.1
 ./configure -j2
 make -j2
 sudo make install


### PR DESCRIPTION
While running `make -j2`, there is an error message: 
```
src/event/ngx_event_openssl.c: In function ‘ngx_ssl_connection_error’:
src/event/ngx_event_openssl.c:2048:21: error: ‘SSL_R_NO_CIPHERS_PASSED’ undeclared (first use in this function); did you mean ‘SSL_R_NO_CIPHERS_SPECIFIED’?
```

The issue is fixed after installing openresty-1.19.1.3 instead of openresty-1.11.2.5.

Updated docs:
- updated code:
```
apt update
apt-get install gcc libssl-dev libpcre3 libpcre3-dev
wget https://openresty.org/download/openresty-1.19.3.1.tar.gz
tar -xvf openresty-1.19.3.1.tar.gz 
cd openresty-1.19.3.1
./configure -j2
make -j2
sudo make install
```
- old code:
```
apt update
apt-get install gcc libssl-dev libpcre3 libpcre3-dev
wget https://openresty.org/download/openresty-1.11.2.5.tar.gz
tar -xvf openresty-1.11.2.5.tar.gz 
cd openresty-1.11.2.5
./configure -j2
make -j2
sudo make install
```