### PR TITLE
docs: fix wrong reference for Docker Images

### DIFF
--- a/docs/source/reference/container-image-refs.md
+++ b/docs/source/reference/container-image-refs.md
@@ -2,30 +2,30 @@
 
 A list of references to all the images used in Gluu enterprise can be found below:
 
-[Config Init](https://github.com/GluuFederation/docker-config-init/blob/4.4/README.md)
+[Config Init](https://hub.docker.com/r/gluufederation/config-init)
 
-[Jackrabbit](https://github.com/GluuFederation/docker-jackrabbit/blob/4.4/README.md)
+[Jackrabbit](https://hub.docker.com/r/gluufederation/jackrabbit)
 
-[OpenDJ / Wren:DS](https://github.com/GluuFederation/docker-opendj/blob/4.4/README.md)
+[OpenDJ / Wren:DS](https://hub.docker.com/r/gluufederation/opendj)
 
-[Persistence](https://github.com/GluuFederation/docker-persistence/blob/4.4/README.md)
+[Persistence](https://hub.docker.com/r/gluufederation/persistence)
 
-[oxAuth](https://github.com/GluuFederation/docker-oxauth/blob/4.4/README.md)
+[oxAuth](https://hub.docker.com/r/gluufederation/oxauth)
 
-[oxTrust](https://github.com/GluuFederation/docker-oxtrust/blob/4.4/README.md)
+[oxTrust](https://hub.docker.com/r/gluufederation/oxtrust)
 
-[oxShibboleth](https://github.com/GluuFederation/docker-oxshibboleth/blob/4.4/README.md)
+[oxShibboleth](https://hub.docker.com/r/gluufederation/oxshibboleth)
 
-[oxPassport](https://github.com/GluuFederation/docker-oxpassport/blob/4.4/README.md)
+[oxPassport](https://hub.docker.com/r/gluufederation/oxpassport)
 
-[FIDO2](https://github.com/GluuFederation/docker-fido2/blob/4.4/README.md)
+[FIDO2](https://hub.docker.com/r/gluufederation/fido2)
 
-[SCIM](https://github.com/GluuFederation/docker-scim/blob/4.4/README.md)
+[SCIM](https://hub.docker.com/r/gluufederation/scim)
 
-[Gluu Cert Manager](https://github.com/GluuFederation/docker-certmanager/blob/4.4/README.md)
+[Gluu Cert Manager](https://hub.docker.com/r/gluufederation/certmanager)
 
-[CacheRefresh Rotation](https://github.com/GluuFederation/docker-cr-rotate/blob/4.4/README.md)
+[CacheRefresh Rotation](https://hub.docker.com/r/gluufederation/cr-rotate)
 
-[Radius](https://github.com/GluuFederation/docker-radius/blob/4.4/README.md)
+[Radius](https://hub.docker.com/r/gluufederation/radius)
 
-[Upgrade](https://github.com/GluuFederation/docker-upgrade/blob/4.4/README.md)
+[Upgrade](https://hub.docker.com/r/gluufederation/upgrade)


### PR DESCRIPTION
PR refers to this [issue](https://github.com/GluuFederation/docs-gluu-server-prod/issues/114) to fix wrong reference for Docker Images