### PR TITLE
docs: fix typo when creating k8s regcred secret

### DIFF
--- a/docs/source/installation-guide/install-kubernetes.md
+++ b/docs/source/installation-guide/install-kubernetes.md
@@ -27,7 +27,7 @@ The Kubernetes deployment of the Gluu Server, also called Cloud Native (CN) Edit
 ## Requirements for accessing docker images and assets
 
 1. Contact sales@gluu.org for credentials to access and pull our docker images. Existing customers should have received the credentials already. 
-2. Follow the [guide](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line) to create a secret in your kubernetes environment holding the docker credentials. Make sure you're creating the scope in the same namespace (create the namespace if doesn't exist yet) that will be used in Gluu installation.
+2. Follow the [guide](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line) to create a secret in your kubernetes environment holding the docker credentials. Make sure you're creating the secret in the same namespace (create the namespace if doesn't exist yet) that will be used in Gluu installation.
 3. If you are using [`pygluu-kubernetes.pyz`](https://github.com/GluuFederation/cloud-native-edition/releases) the tool that parses `values.yaml` you can skip the next steps. We recommend using helm manually.
 4. Inject the secret name in your [`values.yaml`](https://github.com/GluuFederation/cloud-native-edition/blob/4.5/pygluu/kubernetes/templates/helm/gluu/values.yaml) at `image.pullSecrets` for each service.
    For example:


### PR DESCRIPTION
The changeset fixes typo in k8s installation docs.