### PR TITLE
docs: fix api doc version

### DIFF
--- a/docs/source/api-guide/api-reference.md
+++ b/docs/source/api-guide/api-reference.md
@@ -8,9 +8,9 @@ The Gluu Server comes with a variety of APIs to help handle administration and c
 
 Swagger documentation for Gluu Services can be accessed through the following links:
 
-- [oxTrust](https://gluu.org/swagger-ui/?operationsSorter=alpha&url=https://raw.githubusercontent.com/GluuFederation/oxTrust/version_4.4.0/api-server/src/main/resources/META-INF/openapi.yaml)
-- [oxAuth](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/GluuFederation/oxAuth/master/docs/oxAuthSwagger.yaml#/)
-- [SCIM](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/GluuFederation/scim/master/scim-server/src/main/resources/gluu-scim-swagger.yaml)
+- [oxTrust](https://gluu.org/swagger-ui/?operationsSorter=alpha&url=https://raw.githubusercontent.com/GluuFederation/oxTrust/version_4.5.2/api-server/src/main/resources/META-INF/openapi.yaml)
+- [oxAuth](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/GluuFederation/oxAuth/version_4.5.2/docs/oxAuthSwagger.yaml#/)
+- [SCIM](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/GluuFederation/scim/version_4.5.2/scim-server/src/main/resources/gluu-scim-swagger.yaml)
 
 ## Additional Information
 


### PR DESCRIPTION
Current links on `api reference` page are pointing to old version. Update them to latest 4.5.2